### PR TITLE
feat: Envelope message handling and server protobuf integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+# This is a sample Python script.
+
+# Press Shift+F10 to execute it or replace it with your code.
+# Press Double Shift to search everywhere for classes, files, tool windows, actions, and settings.
+
+
+def print_hi(name):
+    # Use a breakpoint in the code line below to debug your script.
+    print(f'Hi, {name}')  # Press Ctrl+F8 to toggle the breakpoint.
+
+
+# Press the green button in the gutter to run the script.
+if __name__ == '__main__':
+    print_hi('PyCharm')
+
+# See PyCharm help at https://www.jetbrains.com/help/pycharm/

--- a/src/smart_home/proto/v1/message.proto
+++ b/src/smart_home/proto/v1/message.proto
@@ -23,10 +23,26 @@ message DeviceResponse {
 	string message = 4;
 }
 
+message DeviceRegisterReq {
+	int32 device_id = 1;
+	string device_type = 2;
+	map<string, string> capabilities = 3;
+	map<string, string> device_state = 4;
+	int64 timestamp = 5;
+}
+
+message DeviceRegisterResp {
+	int32 device_id = 1;
+	bool success = 2;
+	int64 timestamp = 3;
+	optional string cause = 4;
+}
+
 message Envelope {
 	oneof payload {
 		DeviceStateChange device_state_change = 1;
 		DeviceStateUpdate device_state_update = 2;
 		DeviceResponse device_response = 3;
+		DeviceRegisterReq device_register_req = 4;
 	}
 }

--- a/src/smart_home/proto/v1/message.proto
+++ b/src/smart_home/proto/v1/message.proto
@@ -22,3 +22,11 @@ message DeviceResponse {
 	bool success = 3;
 	string message = 4;
 }
+
+message Envelope {
+	oneof payload {
+		DeviceStateChange device_state_change = 1;
+		DeviceStateUpdate device_state_update = 2;
+		DeviceResponse device_response = 3;
+	}
+}

--- a/src/smart_home/server/connection_handler.py
+++ b/src/smart_home/server/connection_handler.py
@@ -1,6 +1,7 @@
 from asyncio import StreamReader, StreamWriter
 
 from smart_home.common.config import config
+from smart_home.server.message_handler import parse_envelope, handle_message
 
 
 async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
@@ -11,12 +12,8 @@ async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
             if not data:
                 break
             
-            print(f"Server recieved: {data}")
-
-            response = f"Server received: {data}"
-
-            writer.write(response.encode("utf-8"))
-            await writer.drain()
+            envelope = parse_envelope(data)
+            handle_message(envelope)
     finally:
         writer.close()
         await writer.wait_closed()

--- a/src/smart_home/server/connection_handler.py
+++ b/src/smart_home/server/connection_handler.py
@@ -1,7 +1,7 @@
 from asyncio import StreamReader, StreamWriter
 
 from smart_home.common.config import config
-from smart_home.server.message_handler import parse_envelope, handle_message
+from smart_home.server.message_handler import parse_envelope, msg_to_event
 
 
 async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
@@ -11,9 +11,9 @@ async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
 
             if not data:
                 break
-            
+
             envelope = parse_envelope(data)
-            handle_message(envelope)
+            event = msg_to_event(envelope, writer)
     finally:
         writer.close()
         await writer.wait_closed()

--- a/src/smart_home/server/connection_handler.py
+++ b/src/smart_home/server/connection_handler.py
@@ -1,18 +1,21 @@
+import base64
 from asyncio import StreamReader, StreamWriter
 
-from smart_home.common.config import config
 from smart_home.server.message_handler import parse_envelope, msg_to_event
 
 
 async def handle_client(reader: StreamReader, writer: StreamWriter) -> None:
     try:
         while True:
-            data = await reader.read(config.buffer_size)
+            line = await reader.readline()
 
-            if not data:
+            if not line:
                 break
 
-            envelope = parse_envelope(data)
+            request_id, payload_b64 = line.decode().strip().split("|", 1)
+            raw_bytes = base64.b64decode(payload_b64)
+
+            envelope = parse_envelope(raw_bytes)
             event = msg_to_event(envelope, writer)
     finally:
         writer.close()

--- a/src/smart_home/server/events.py
+++ b/src/smart_home/server/events.py
@@ -1,0 +1,20 @@
+from asyncio import StreamWriter
+from dataclasses import dataclass
+
+
+@dataclass
+class DeviceStateChangeEvent:
+    device_id: int
+    writer: StreamWriter
+
+
+@dataclass
+class DeviceResponseEvent:
+    device_id: int
+    writer: StreamWriter
+
+
+@dataclass
+class DeviceRegisterEvent:
+    device_id: int
+    writer: StreamWriter

--- a/src/smart_home/server/events.py
+++ b/src/smart_home/server/events.py
@@ -6,15 +6,25 @@ from dataclasses import dataclass
 class DeviceStateChangeEvent:
     device_id: int
     writer: StreamWriter
+    timestamp: int
+    device_type: int
+    parameters: dict[str, str]
 
 
 @dataclass
 class DeviceResponseEvent:
     device_id: int
     writer: StreamWriter
+    timestamp: int
+    success: bool
+    message: str
 
 
 @dataclass
 class DeviceRegisterEvent:
     device_id: int
     writer: StreamWriter
+    device_type: str
+    capabilities: dict[str, str]
+    device_state: dict[str, str]
+    timestamp: int

--- a/src/smart_home/server/message_handler.py
+++ b/src/smart_home/server/message_handler.py
@@ -27,19 +27,32 @@ def msg_to_event(
     msg_type = envelope.WhichOneof("payload")
 
     if msg_type == "device_state_change":
+        msg = envelope.device_state_change
         return DeviceStateChangeEvent(
-            device_id=envelope.device_state_change.device_id,
+            device_id=msg.device_id,
             writer=writer,
+            timestamp=msg.timestamp,
+            device_type=msg.device_type,
+            parameters=dict(msg.parameters),
         )
     elif msg_type == "device_response":
+        msg = envelope.device_response
         return DeviceResponseEvent(
-            device_id=envelope.device_response.device_id,
+            device_id=msg.device_id,
             writer=writer,
+            timestamp=msg.timestamp,
+            success=msg.success,
+            message=msg.message,
         )
     elif msg_type == "device_register_req":
+        msg = envelope.device_register_req
         return DeviceRegisterEvent(
-            device_id=envelope.device_register_req.device_id,
+            device_id=msg.device_id,
             writer=writer,
+            device_type=msg.device_type,
+            capabilities=dict(msg.capabilities),
+            device_state=dict(msg.device_state),
+            timestamp=msg.timestamp,
         )
     return None
 

--- a/src/smart_home/server/message_handler.py
+++ b/src/smart_home/server/message_handler.py
@@ -1,4 +1,7 @@
+from asyncio import StreamWriter
+
 from smart_home.proto.v1 import message_pb2
+from smart_home.server.events import DeviceStateChangeEvent, DeviceResponseEvent, DeviceRegisterEvent
 
 
 def parse_envelope(data: bytes) -> message_pb2.Envelope:
@@ -16,6 +19,29 @@ def build_envelope(message) -> bytes:
     elif isinstance(message, message_pb2.DeviceResponse):
         envelope.device_response.CopyFrom(message)
     return envelope.SerializeToString()
+
+
+def msg_to_event(
+    envelope: message_pb2.Envelope, writer: StreamWriter
+) -> DeviceStateChangeEvent | DeviceResponseEvent | DeviceRegisterEvent | None:
+    msg_type = envelope.WhichOneof("payload")
+
+    if msg_type == "device_state_change":
+        return DeviceStateChangeEvent(
+            device_id=envelope.device_state_change.device_id,
+            writer=writer,
+        )
+    elif msg_type == "device_response":
+        return DeviceResponseEvent(
+            device_id=envelope.device_response.device_id,
+            writer=writer,
+        )
+    elif msg_type == "device_register_req":
+        return DeviceRegisterEvent(
+            device_id=envelope.device_register_req.device_id,
+            writer=writer,
+        )
+    return None
 
 
 def handle_message(envelope: message_pb2.Envelope):

--- a/src/smart_home/server/message_handler.py
+++ b/src/smart_home/server/message_handler.py
@@ -1,0 +1,36 @@
+from smart_home.proto.v1 import message_pb2
+
+
+def parse_envelope(data: bytes) -> message_pb2.Envelope:
+    envelope = message_pb2.Envelope()
+    envelope.ParseFromString(data)
+    return envelope
+
+
+def build_envelope(message) -> bytes:
+    envelope = message_pb2.Envelope()
+    if isinstance(message, message_pb2.DeviceStateChange):
+        envelope.device_state_change.CopyFrom(message)
+    elif isinstance(message, message_pb2.DeviceStateUpdate):
+        envelope.device_state_update.CopyFrom(message)
+    elif isinstance(message, message_pb2.DeviceResponse):
+        envelope.device_response.CopyFrom(message)
+    return envelope.SerializeToString()
+
+
+def handle_message(envelope: message_pb2.Envelope):
+    msg_type = envelope.WhichOneof("payload")
+
+    if msg_type == "device_state_change":
+        msg = envelope.device_state_change
+        print(f"Device {msg.device_id} state change: {dict(msg.parameters)}")
+
+    elif msg_type == "device_response":
+        msg = envelope.device_response
+        status = "OK" if msg.success else "FAILED"
+        print(f"Device {msg.device_id} response: {status} - {msg.message}")
+
+    else:
+        print(f"Unknown message type: {msg_type}")
+
+    return msg_type

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from smart_home.proto.v1 import message_pb2
+from smart_home.server.message_handler import handle_message, parse_envelope, build_envelope
+
+
+def test_handle_message_recognizes_state_change():
+    envelope = message_pb2.Envelope()
+    envelope.device_state_change.device_id = 1
+
+    assert handle_message(envelope) == "device_state_change"
+
+
+def test_handle_message_recognizes_device_response():
+    envelope = message_pb2.Envelope()
+    envelope.device_response.device_id = 2
+
+    assert handle_message(envelope) == "device_response"
+
+
+def test_full_flow_device_state_change():
+    msg = message_pb2.DeviceStateChange()
+    msg.device_id = 1
+    msg.parameters["temperature"] = "24.6"
+
+    data = build_envelope(msg)
+    envelope = parse_envelope(data)
+    result = handle_message(envelope)
+
+    assert result == "device_state_change"
+
+
+def test_full_flow_device_response():
+    msg = message_pb2.DeviceResponse()
+    msg.device_id = 2
+    msg.success = True
+    msg.message = "Light turned on"
+
+    data = build_envelope(msg)
+    envelope = parse_envelope(data)
+    result = handle_message(envelope)
+
+    assert result == "device_response"


### PR DESCRIPTION
- Added Envelope wrapper message with oneof to message.proto — allows the server to distinguish between different message types (DeviceStateChange, DeviceStateUpdate, DeviceResponse)
- Created message_handler.py with three functions:
    - parse_envelope — deserializes incoming bytes into an Envelope object
    - build_envelope — wraps a message into an Envelope and serializes to bytes
    - handle_message — identifies the message type and processes it
- Updated connection_handler.py to use the new message handler instead of echoing raw text
- Added tests for message handling logic and full flow (build → serialize → deserialize → handle)

How to test:
python -m pytest tests/test_message_handler.py