### PR TITLE
Client fixes

### DIFF
--- a/src/smart_home/client/client.py
+++ b/src/smart_home/client/client.py
@@ -25,8 +25,11 @@ async def start_client(args: argparse.Namespace) -> None:
 
     connection_handler = ConnectionHandler(reader, writer, args.device_type)
     connection_handler.event_callback = bus.put_event
-    await register_device(reader, writer, args.device_type)
     await connection_handler.start()
+
+    registered_device_id = await register_device(connection_handler, args.device_type)
+    if registered_device_id is None:
+        print("Registration did not complete.")
 
     try:
         while True:

--- a/src/smart_home/client/controllers/event_handler.py
+++ b/src/smart_home/client/controllers/event_handler.py
@@ -1,44 +1,48 @@
 import asyncio
-from typing import Callable
+import inspect
+from typing import Any, Callable
 
 class EventHandler:
-    def __init__(self):
-        self._queue: asyncio.Queue = asyncio.Queue()
-        self._subscribers: list[Callable] = []
-        self._running = True
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._subscribers: list[Callable[[Any], Any]] = []
+        self._running = False
         self._task: asyncio.Task | None = None
 
-    def subscribe(self, callback):
-        """ DeviceStorage or AI"""
+    def subscribe(self, callback: Callable[[Any], Any]) -> None:
+        """Register sync or async callback for incoming events."""
         self._subscribers.append(callback)
 
-    async def put_event(self, data):
-        """raw data"""
+    async def put_event(self, data: Any) -> None:
+        """Push raw event data into the internal queue."""
         await self._queue.put(data)
 
-
-    async def start(self):
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
         self._running = True
-        self._task = asyncio.create_task(self.run(), name = "EventHandler")
-    async def run(self):
-        
-        while self._running:
-            try:
-                event_data = await asyncio.wait_for( self._queue.get(), timeout=1.0)
+        self._task = asyncio.create_task(self.run(), name="EventHandler")
 
-                await asyncio.gather(
-                    *[cb(event_data) for cb in self._subscribers],
-                    return_exceptions=True
-                )
-                self._queue.task_done()
-                for callback in self._subscribers:
-                    callback(event_data)
-                
-                self._queue.task_done()
-            except asyncio.TimeoutError:
-                continue
+    async def run(self) -> None:
+        try:
+            while self._running:
+                event_data = await self._queue.get()
+                try:
+                    for callback in self._subscribers:
+                        result = callback(event_data)
+                        if inspect.isawaitable(result):
+                            await result
+                finally:
+                    self._queue.task_done()
+        except asyncio.CancelledError:
+            raise
 
-    async def stop(self):
+    async def stop(self) -> None:
         self._running = False
         if self._task:
-            await self._task
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None

--- a/src/smart_home/client/controllers/message_coder.py
+++ b/src/smart_home/client/controllers/message_coder.py
@@ -27,6 +27,23 @@ def decode_register_response(response_b64: str) -> message_pb2.DeviceRegisterRes
     return message_pb2.DeviceRegisterResp.FromString(resp_bytes)
 
 
+def create_state_change_message(
+    device_id: int,
+    parameters: dict[str, str],
+    device_type: int,
+) -> message_pb2.DeviceStateChange:
+    """Create a DeviceStateChange protobuf object with timestamp and parameters."""
+    msg = message_pb2.DeviceStateChange()
+    msg.device_id = device_id
+    msg.timestamp = int(time())
+    msg.device_type = device_type
+
+    if parameters:
+        msg.parameters.update(parameters)
+
+    return msg
+
+
 def encode_state_change(device_id: int, parameters: dict[str, str], device_type: int) -> str:
     """
     Encodes a DeviceStateChange message into a base64 string.
@@ -39,14 +56,11 @@ def encode_state_change(device_id: int, parameters: dict[str, str], device_type:
     Returns:
         A base64 encoded string of the serialized protobuf message.
     """
-    msg = message_pb2.DeviceStateChange()
-
-    msg.device_id = device_id
-    msg.timestamp = int(time())
-    msg.device_type = device_type
-    
-    if parameters:
-        msg.parameters.update(parameters)
+    msg = create_state_change_message(
+        device_id=device_id,
+        parameters=parameters,
+        device_type=device_type,
+    )
 
     payload_bytes = msg.SerializeToString()
     payload_b64 = base64.b64encode(payload_bytes).decode("utf-8")

--- a/src/smart_home/client/controllers/message_sender.py
+++ b/src/smart_home/client/controllers/message_sender.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from asyncio import StreamReader, StreamWriter
-
 from .connection_handler import ConnectionHandler
 from .message_coder import decode_register_response, encode_register_request
 
 
-async def register_device(reader: StreamReader, writer: StreamWriter, device_type: str) -> None:
-    handler = ConnectionHandler(reader, writer, device_type)
-    await handler.start()
-
+async def register_device(handler: ConnectionHandler, device_type: str) -> int | None:
     try:
         payload_b64, req = encode_register_request(device_type)
         print(f"Register request sent (Type: {device_type}, ID: {req.device_id})...")
@@ -19,13 +14,14 @@ async def register_device(reader: StreamReader, writer: StreamWriter, device_typ
 
         if resp.success:
             print(f"Device registered successfully (At {resp.timestamp})")
+            return resp.device_id
         else:
             print(f"Registration failed: {resp.cause}")
+            return None
 
     except TimeoutError:
         print("Server failed to respond")
+        return None
     except Exception as e:
         print(f"Critical connection error: {e}")
-    finally:
-        await handler.stop()
-        print("Client stopped")
+        return None

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import sys
+import asyncio
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+from smart_home.client.controllers.event_handler import EventHandler
+
+
+def test_event_is_dispatched_once_to_each_subscriber():
+    async def scenario() -> None:
+        bus = EventHandler()
+        calls: list[tuple[str, str]] = []
+
+        def sub_a(data: str) -> None:
+            calls.append(("a", data))
+
+        def sub_b(data: str) -> None:
+            calls.append(("b", data))
+
+        bus.subscribe(sub_a)
+        bus.subscribe(sub_b)
+
+        await bus.start()
+        await bus.put_event("E1")
+        await bus._queue.join()
+        await bus.stop()
+
+        assert calls.count(("a", "E1")) == 1
+        assert calls.count(("b", "E1")) == 1
+        assert len(calls) == 2
+
+    asyncio.run(scenario())
+
+
+def test_sync_and_async_subscribers_both_run():
+    async def scenario() -> None:
+        bus = EventHandler()
+        calls: list[str] = []
+
+        def sync_sub(data: str) -> None:
+            calls.append(f"sync:{data}")
+
+        async def async_sub(data: str) -> None:
+            await asyncio.sleep(0)
+            calls.append(f"async:{data}")
+
+        bus.subscribe(sync_sub)
+        bus.subscribe(async_sub)
+
+        await bus.start()
+        await bus.put_event("E2")
+        await bus._queue.join()
+        await bus.stop()
+
+        assert "sync:E2" in calls
+        assert "async:E2" in calls
+        assert len(calls) == 2
+
+    asyncio.run(scenario())
+
+
+def test_stop_cancels_background_task_cleanly():
+    async def scenario() -> None:
+        bus = EventHandler()
+        await bus.start()
+
+        assert bus._task is not None
+        assert not bus._task.done()
+
+        await bus.stop()
+
+        assert bus._task is None
+        assert bus._running is False
+
+    asyncio.run(scenario())

--- a/tests/test_protobuf_pytest.py
+++ b/tests/test_protobuf_pytest.py
@@ -10,6 +10,8 @@ if str(SRC_DIR) not in sys.path:
 
 
 from smart_home.proto.v1 import message_pb2
+from smart_home.client.controllers import message_coder
+import base64
 import time
 
 TIMESTAMP = int(time.time())
@@ -64,3 +66,33 @@ def test_device_response_serialization():
     assert received.success == True
     assert received.timestamp == TIMESTAMP
     assert received.message == "Swiatlo zapalone o 16:00"
+
+
+def test_create_state_change_message_from_coder():
+    msg = message_coder.create_state_change_message(
+        device_id=7,
+        parameters={"power": "ON", "brightness": "80"},
+        device_type=1,
+    )
+
+    assert msg.device_id == 7
+    assert msg.device_type == 1
+    assert msg.parameters["power"] == "ON"
+    assert msg.parameters["brightness"] == "80"
+    assert msg.timestamp > 0
+
+
+def test_encode_state_change_from_coder_roundtrip():
+    payload_b64 = message_coder.encode_state_change(
+        device_id=8,
+        parameters={"temperature": "24.5"},
+        device_type=2,
+    )
+
+    payload = base64.b64decode(payload_b64)
+    decoded = message_pb2.DeviceStateChange.FromString(payload)
+
+    assert decoded.device_id == 8
+    assert decoded.device_type == 2
+    assert decoded.parameters["temperature"] == "24.5"
+    assert decoded.timestamp > 0


### PR DESCRIPTION
**EventHandler Improvements**
Removed duplicate subscriber execution
Removed duplicate queue task_done calls
Added support for both synchronous and asynchronous subscribers
Improved start behavior to avoid creating multiple background tasks
Improved stop behavior by cancelling and awaiting the running task safely
Added stricter type annotations for queue payloads and subscriber callbacks

**Device registration refactor**
register_devicen ow accepts an existing ConnectionHandler instead of creating a new one.
Function now returns device_id on success and None on failure.
Registration no longer closes the active connection internally.

**Client flow update**
Registration is executed using the already started shared handler.
Added handling for unsuccessful registration result (None).

**Message coder refactor**
Added create_state_change_message to build the protobuf object.
encode_state_change now only handles serialization/base64 encoding instead of building whole message

**Test coverage**
