### PR TITLE
Client subhandler

### DIFF
--- a/src/smart_home/client/client.py
+++ b/src/smart_home/client/client.py
@@ -5,6 +5,8 @@ from ..common.config import config
 from ..client.controllers.connection_handler import ConnectionHandler
 from ..client.controllers.message_sender import register_device
 from ..client.controllers.event_handler import EventHandler
+from ..client.controllers.event_router import ClientEventRouter
+from ..client.models.containers import DeviceStorage
 
 async def start_client(args: argparse.Namespace) -> None:
     reader: StreamReader
@@ -17,10 +19,9 @@ async def start_client(args: argparse.Namespace) -> None:
     print(f"Connected to server {host}:{port} as '{args.device_type}'")
 
     bus = EventHandler()
-    '''
-    TO BE IMPLEMENTED
-    Subscribing the SubHandlers
-    '''
+    storage = DeviceStorage()
+    router = ClientEventRouter(storage)
+    bus.subscribe(router.handle)
     await bus.start()
 
     connection_handler = ConnectionHandler(reader, writer, args.device_type)

--- a/src/smart_home/client/controllers/device_factory.py
+++ b/src/smart_home/client/controllers/device_factory.py
@@ -1,4 +1,4 @@
-from ..models.devices import Device
+from ..models.device import Device
 
 
 def create_lamp(device_id: int, device_type: str, capabilities: dict, device_state: dict) -> Device:

--- a/src/smart_home/client/controllers/device_registry.py
+++ b/src/smart_home/client/controllers/device_registry.py
@@ -1,4 +1,4 @@
-from models.devices import Device
+from models.device import Device
 from models.containers import DeviceStorage
 
 

--- a/src/smart_home/client/controllers/event_router.py
+++ b/src/smart_home/client/controllers/event_router.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from ..models.containers import DeviceStorage
+from ..models.device_storage import update_device_state
+from . import message_coder
+
+
+class ClientEventRouter:
+    """Routes incoming client events to dedicated subhandlers."""
+
+    def __init__(self, storage: DeviceStorage) -> None:
+        self._storage = storage
+
+    def handle(self, event_data: str) -> bool:
+        """Handle one raw incoming event payload.
+
+        Returns True when the event was recognized and handled.
+        """
+        return self._handle_state_update(event_data)
+
+    def _handle_state_update(self, event_data: str) -> bool:
+        state_update = message_coder.decode_state_update_message(event_data)
+        if state_update is None:
+            return False
+
+        success, message = update_device_state(
+            storage=self._storage,
+            device_id=state_update.device_id,
+            new_state=dict(state_update.parameters),
+        )
+
+        if not success:
+            print(f"WARN: {message}")
+
+        return success

--- a/src/smart_home/client/controllers/message_coder.py
+++ b/src/smart_home/client/controllers/message_coder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 
 from time import time
 from ...proto.v1 import message_pb2
@@ -66,3 +67,26 @@ def encode_state_change(device_id: int, parameters: dict[str, str], device_type:
     payload_b64 = base64.b64encode(payload_bytes).decode("utf-8")
     
     return payload_b64
+
+
+def decode_state_update_message(response_b64: str) -> message_pb2.DeviceStateUpdate | None:
+    """Decode base64 payload to DeviceStateUpdate when possible.
+
+    Returns None when the payload is not valid base64/protobuf state update data.
+    """
+    try:
+        payload = base64.b64decode(response_b64, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    msg = message_pb2.DeviceStateUpdate()
+    try:
+        msg.ParseFromString(payload)
+    except Exception:
+        return None
+
+    has_content = bool(msg.parameters) or msg.command_type != 0 or msg.timestamp != 0
+    if msg.device_id <= 0 or not has_content:
+        return None
+
+    return msg

--- a/src/smart_home/client/models/containers.py
+++ b/src/smart_home/client/models/containers.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Dict
-from .devices import Device
+from .device import Device
 
 @dataclass
 class DeviceStorage:

--- a/tests/test_state_update_handler.py
+++ b/tests/test_state_update_handler.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import sys
+import base64
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+from smart_home.client.controllers.event_router import ClientEventRouter
+from smart_home.client.models.containers import DeviceStorage
+from smart_home.client.models.device import Device
+from smart_home.client.models.device_storage import save_device
+from smart_home.proto.v1 import message_pb2
+
+
+def test_device_state_update_event_updates_storage():
+    storage = DeviceStorage()
+    router = ClientEventRouter(storage)
+    device = Device(device_id=7, device_type="lamp", device_state={"power": "OFF"})
+    ok, _ = save_device(storage, device)
+    assert ok is True
+
+    update = message_pb2.DeviceStateUpdate()
+    update.device_id = 7
+    update.timestamp = 1710000000
+    update.command_type = 1
+    update.parameters["power"] = "ON"
+
+    payload_b64 = base64.b64encode(update.SerializeToString()).decode("utf-8")
+
+    handled = router.handle(payload_b64)
+
+    assert handled is True
+    assert storage.lamps[7].device_state["power"] == "ON"
+
+
+def test_non_update_payload_is_ignored():
+    storage = DeviceStorage()
+    router = ClientEventRouter(storage)
+
+    handled = router.handle("not_base64_payload")
+
+    assert handled is False
+
+
+def test_update_for_unknown_device_returns_false():
+    storage = DeviceStorage()
+    router = ClientEventRouter(storage)
+
+    update = message_pb2.DeviceStateUpdate()
+    update.device_id = 404
+    update.timestamp = 1710000000
+    update.command_type = 1
+    update.parameters["power"] = "ON"
+
+    payload_b64 = base64.b64encode(update.SerializeToString()).decode("utf-8")
+
+    handled = router.handle(payload_b64)
+
+    assert handled is False


### PR DESCRIPTION
**Changes Made**
The client event flow was refactored to separate generic event dispatching from event-specific handling. EventHandler now acts as a lightweight event bus: it receives raw incoming events, stores them in a queue, and forwards them to registered subscribers. The actual business logic was moved into EventRouter which currently handles DeviceStateUpdate messages and applies them to local DeviceStorage.

ConncetionHandler receives messages, EventHandler dispatches them and EventRouter decides how to process them.
Also added tests to the subhandler.

**How to Add More Subhandlers**

To add another subhandler, extend EventRouter with new private handler method for the new event type, then update the main handle() method to route the raw payload to the right subhandler.  If the new event uses a different protobuf message, add a matching decoder in messege_coder.py first, then have the router call it before applying any logic.

In practice, the pattern is:

Decode the raw payload into a specific protobuf message.
Check whether the message is valid and intended for that handler.
Apply the corresponding action to local state or emit another side effect.
Return whether the event was recognized and handled.