### PR TITLE
Feat server/bug fixes and exception handling

### DIFF
--- a/src/smart_home/server/events.py
+++ b/src/smart_home/server/events.py
@@ -7,7 +7,7 @@ class DeviceStateChangeEvent:
     device_id: int
     writer: StreamWriter
     timestamp: int
-    device_type: int
+    device_type: str
     parameters: dict[str, str]
 
 

--- a/src/smart_home/server/processors.py
+++ b/src/smart_home/server/processors.py
@@ -9,25 +9,36 @@ class RegisterProcessor:
         self._registry = registry
 
     async def handle(self, event: DeviceRegisterEvent) -> None:
-        device = RegisteredDevice(
-            device_id=event.device_id,
-            writer=event.writer,
-            device_type=event.device_type,
-            capabilities=event.capabilities,
-            device_state=event.device_state,
-            timestamp=event.timestamp,
-        )
+        try:
+            device = RegisteredDevice(
+                device_id=event.device_id,
+                writer=event.writer,
+                device_type=event.device_type,
+                capabilities=event.capabilities,
+                device_state=event.device_state,
+                timestamp=event.timestamp,
+            )
 
-        await self._registry.register(device)
+            await self._registry.register(device)
 
-        response = message_pb2.DeviceRegisterResp()
-        response.device_id = event.device_id
-        response.success = True
-        response.timestamp = event.timestamp
+            response = message_pb2.DeviceRegisterResp()
+            response.device_id = event.device_id
+            response.success = True
+            response.timestamp = event.timestamp
 
-        data = build_envelope(response)
-        event.writer.write(data)
-        await event.writer.drain()
+        except Exception as e:
+            response = message_pb2.DeviceRegisterResp()
+            response.device_id = event.device_id
+            response.success = False
+            response.timestamp = event.timestamp
+            response.error_message = str(e)
+
+        try:
+            data = build_envelope(response)
+            event.writer.write(data)
+            await event.writer.drain()
+        except Exception as e:
+            pass
 
         print(f"[RegisterProcessor] Device {event.device_id} registered")
 

--- a/src/smart_home/server/registry.py
+++ b/src/smart_home/server/registry.py
@@ -21,10 +21,15 @@ class DeviceRegistry:
 
     async def register(self, device: RegisteredDevice) -> None:
         async with self._lock:
+            if device.device_id in self._devices_by_id:
+                raise ValueError(
+                    f"Device with id {device.device_id} is already registered"
+                )
+
             self._devices_by_id[device.device_id] = device
             self._device_id_by_writer[id(device.writer)] = device.device_id
 
-            print(f"[DeviceRegistry] Registered device {device.device_id}")
+        print(f"[DeviceRegistry] Registered device {device.device_id}")
 
     async def get_by_device_id(self, device_id: int) -> RegisteredDevice | None:
         async with self._lock:

--- a/tests/test_registration_duplicates.py
+++ b/tests/test_registration_duplicates.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+import pytest
+
+from smart_home.server.registry import DeviceRegistry, RegisteredDevice
+
+@pytest.mark.asyncio
+async def test_registration_duplicates() -> None:
+    registry = DeviceRegistry()
+
+    writer_1 = Mock()
+    writer_2 = Mock()
+
+    device_1 = RegisteredDevice(
+        device_id=10,
+        writer=writer_1,
+        device_type="thermostat",
+        capabilities={"mode": "heat"},
+        device_state={"temperature": "22"},
+        timestamp=111,
+    )
+
+    device_2 = RegisteredDevice(
+        device_id=10,
+        writer=writer_2,
+        device_type="thermostat",
+        capabilities={"mode": "cool"},
+        device_state={"temperature": "19"},
+        timestamp=222,
+    )
+
+    await registry.register(device_1)
+
+    with pytest.raises(ValueError):
+        await registry.register(device_2)
+
+    stored = await registry.get_by_device_id(10)
+    assert stored is not None
+    assert stored.device_id == 10
+    assert stored.writer is writer_1
+    assert stored.capabilities == {"mode": "heat"}
+    assert stored.device_state == {"temperature": "22"}
+    assert stored.timestamp == 111


### PR DESCRIPTION
## Summary

This PR improves device registration logic and error handling.

## Changes

- Change `DeviceStateChangeEvent.device_type` from int to string
- Add exception handling in `RegisterProcessor`
- Ensure `response.success` reflects actual operation result
- Add test for duplicate device registration
- Prevent registering multiple devices with the same `device_id`

## Notes

- Device registration now fails if a device with the same ID is already connected