### PR TITLE
Add in-memory task database

### DIFF
--- a/src/smart_home/server/events.py
+++ b/src/smart_home/server/events.py
@@ -9,6 +9,11 @@ class TickEvent:
 
 
 @dataclass
+class TaskDueEvent:
+    task_id: int
+
+
+@dataclass
 class DeviceStateChangeEvent:
     device_id: int
     writer: StreamWriter

--- a/src/smart_home/server/tasks.py
+++ b/src/smart_home/server/tasks.py
@@ -12,10 +12,12 @@ class ScheduledTask:
 
 class TaskDatabase:
     def __init__(self) -> None:
+        """Create an empty in-memory task store."""
         self._tasks_by_id: dict[int, ScheduledTask] = {}
         self._lock = asyncio.Lock()
 
     async def add_task(self, task: ScheduledTask) -> bool:
+        """Add a task if its ID is not already stored."""
         async with self._lock:
             if task.task_id in self._tasks_by_id:
                 return False
@@ -24,11 +26,13 @@ class TaskDatabase:
             return True
 
     async def get_by_task_id(self, task_id: int) -> ScheduledTask | None:
+        """Return a task by ID, or None when it does not exist."""
         async with self._lock:
             task = self._tasks_by_id.get(task_id)
             return _copy_task(task) if task is not None else None
 
     async def get_due_tasks(self, timestamp: int) -> list[ScheduledTask]:
+        """Return tasks scheduled at or before the given timestamp."""
         async with self._lock:
             return [
                 _copy_task(task)
@@ -37,6 +41,7 @@ class TaskDatabase:
             ]
 
     async def pop_due_tasks(self, timestamp: int) -> list[ScheduledTask]:
+        """Return and remove tasks scheduled at or before the timestamp."""
         async with self._lock:
             due_tasks = [
                 task
@@ -50,6 +55,7 @@ class TaskDatabase:
             return [_copy_task(task) for task in due_tasks]
 
     async def remove_task(self, task_id: int) -> bool:
+        """Remove a task by ID and report whether it existed."""
         async with self._lock:
             return self._tasks_by_id.pop(task_id, None) is not None
 

--- a/src/smart_home/server/tasks.py
+++ b/src/smart_home/server/tasks.py
@@ -1,0 +1,63 @@
+import asyncio
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScheduledTask:
+    task_id: int
+    device_id: int
+    parameters: dict[str, str]
+    time: int
+
+
+class TaskDatabase:
+    def __init__(self) -> None:
+        self._tasks_by_id: dict[int, ScheduledTask] = {}
+        self._lock = asyncio.Lock()
+
+    async def add_task(self, task: ScheduledTask) -> bool:
+        async with self._lock:
+            if task.task_id in self._tasks_by_id:
+                return False
+
+            self._tasks_by_id[task.task_id] = _copy_task(task)
+            return True
+
+    async def get_by_task_id(self, task_id: int) -> ScheduledTask | None:
+        async with self._lock:
+            task = self._tasks_by_id.get(task_id)
+            return _copy_task(task) if task is not None else None
+
+    async def get_due_tasks(self, timestamp: int) -> list[ScheduledTask]:
+        async with self._lock:
+            return [
+                _copy_task(task)
+                for task in self._tasks_by_id.values()
+                if task.time <= timestamp
+            ]
+
+    async def pop_due_tasks(self, timestamp: int) -> list[ScheduledTask]:
+        async with self._lock:
+            due_tasks = [
+                task
+                for task in self._tasks_by_id.values()
+                if task.time <= timestamp
+            ]
+
+            for task in due_tasks:
+                self._tasks_by_id.pop(task.task_id, None)
+
+            return [_copy_task(task) for task in due_tasks]
+
+    async def remove_task(self, task_id: int) -> bool:
+        async with self._lock:
+            return self._tasks_by_id.pop(task_id, None) is not None
+
+
+def _copy_task(task: ScheduledTask) -> ScheduledTask:
+    return ScheduledTask(
+        task_id=task.task_id,
+        device_id=task.device_id,
+        parameters=dict(task.parameters),
+        time=task.time,
+    )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,115 @@
+import pytest
+
+from smart_home.server.events import TaskDueEvent
+from smart_home.server.tasks import ScheduledTask, TaskDatabase
+
+
+@pytest.mark.asyncio
+async def test_add_task_returns_false_for_duplicate_task_id() -> None:
+    database = TaskDatabase()
+    task = ScheduledTask(
+        task_id=1,
+        device_id=10,
+        parameters={"power": "ON"},
+        time=100,
+    )
+
+    assert await database.add_task(task) is True
+    assert await database.add_task(task) is False
+
+    stored = await database.get_by_task_id(1)
+    assert stored == task
+
+
+@pytest.mark.asyncio
+async def test_get_due_tasks_returns_tasks_due_at_or_before_timestamp() -> None:
+    database = TaskDatabase()
+    due_task = ScheduledTask(
+        task_id=1,
+        device_id=1,
+        parameters={"temperature": "22"},
+        time=100,
+    )
+    later_task = ScheduledTask(
+        task_id=2,
+        device_id=2,
+        parameters={"power": "OFF"},
+        time=101,
+    )
+
+    await database.add_task(due_task)
+    await database.add_task(later_task)
+
+    assert await database.get_due_tasks(100) == [due_task]
+
+
+@pytest.mark.asyncio
+async def test_pop_due_tasks_removes_returned_tasks() -> None:
+    database = TaskDatabase()
+    due_task = ScheduledTask(
+        task_id=1,
+        device_id=1,
+        parameters={"power": "ON"},
+        time=100,
+    )
+    later_task = ScheduledTask(
+        task_id=2,
+        device_id=2,
+        parameters={"power": "OFF"},
+        time=200,
+    )
+
+    await database.add_task(due_task)
+    await database.add_task(later_task)
+
+    due_tasks = await database.pop_due_tasks(150)
+
+    assert due_tasks == [due_task]
+    assert await database.get_by_task_id(1) is None
+    assert await database.get_by_task_id(2) == later_task
+    assert await database.pop_due_tasks(150) == []
+
+
+@pytest.mark.asyncio
+async def test_remove_task_returns_whether_task_existed() -> None:
+    database = TaskDatabase()
+    task = ScheduledTask(
+        task_id=1,
+        device_id=10,
+        parameters={},
+        time=100,
+    )
+
+    await database.add_task(task)
+
+    assert await database.remove_task(1) is True
+    assert await database.remove_task(1) is False
+
+
+@pytest.mark.asyncio
+async def test_task_parameters_are_copied_at_storage_boundaries() -> None:
+    database = TaskDatabase()
+    parameters = {"power": "ON"}
+    task = ScheduledTask(
+        task_id=1,
+        device_id=10,
+        parameters=parameters,
+        time=100,
+    )
+
+    await database.add_task(task)
+    parameters["power"] = "OFF"
+
+    stored = await database.get_by_task_id(1)
+    assert stored is not None
+    assert stored.parameters == {"power": "ON"}
+
+    stored.parameters["power"] = "DIMMED"
+
+    stored_again = await database.get_by_task_id(1)
+    assert stored_again is not None
+    assert stored_again.parameters == {"power": "ON"}
+
+
+def test_task_due_event_carries_task_id() -> None:
+    assert TaskDueEvent(task_id=1).task_id == 1


### PR DESCRIPTION
## Summary
Adds a simple in-memory task database for future scheduler support. Tasks store `task_id`, `device_id`, `parameters`, and scheduled `time`, with APIs to add, inspect, remove, and claim due tasks.

Also adds `TaskDueEvent` so a future tick-based scheduler can publish due task IDs for execution.

## Tests
- Added task database unit tests
- Verified due-task lookup, duplicate handling, removal, and parameter copying