### PR TITLE
feat: add StateUpdateProcessor and DailyTaskReset for #55

### DIFF
--- a/src/smart_home/server/daily_task_reset.py
+++ b/src/smart_home/server/daily_task_reset.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime, timezone
+
+from smart_home.server.events import TickEvent
+from smart_home.server.tasks import TaskDatabase
+
+
+class DailyTaskReset:
+    def __init__(self, task_database: TaskDatabase) -> None:
+        self._task_database = task_database
+        self._last_seen_date: date | None = None
+
+    async def handle(self, event: TickEvent) -> None:
+        current_date = datetime.fromtimestamp(event.timestamp, tz=timezone.utc).date()
+        if self._last_seen_date is None:
+            self._last_seen_date = current_date
+            return
+        if current_date != self._last_seen_date:
+            count = await self._task_database.reset_dispatched_flags()
+            print(f"[DailyTaskReset] Reset {count} task(s) at {current_date}")
+            self._last_seen_date = current_date

--- a/src/smart_home/server/events.py
+++ b/src/smart_home/server/events.py
@@ -7,7 +7,6 @@ from smart_home.proto.v1 import message_pb2
 class TickEvent:
     timestamp: int
 
-
 @dataclass
 class TaskDueEvent:
     task_id: int
@@ -24,7 +23,7 @@ class DeviceStateChangeEvent:
 
 
 @dataclass
-class DeviceResponseEvent:
+class DeviceStateChangeRespEvent:
     device_id: int
     writer: StreamWriter
     request_id: str
@@ -42,3 +41,7 @@ class DeviceRegisterEvent:
     capabilities: dict[str, str]
     device_state: dict[str, str]
     timestamp: int
+
+@dataclass
+class TaskDueEvent:
+    task_id: int

--- a/src/smart_home/server/events.py
+++ b/src/smart_home/server/events.py
@@ -9,6 +9,11 @@ class TickEvent:
 
 
 @dataclass
+class TaskDueEvent:
+    task_id: int
+
+
+@dataclass
 class DeviceStateChangeEvent:
     device_id: int
     writer: StreamWriter

--- a/src/smart_home/server/processors/__init__.py
+++ b/src/smart_home/server/processors/__init__.py
@@ -3,9 +3,4 @@ from smart_home.server.processors.response import ResponseProcessor
 from smart_home.server.processors.state_change import StateChangeProcessor
 from smart_home.server.processors.state_update import StateUpdateProcessor
 
-__all__ = [
-    "RegisterProcessor",
-    "ResponseProcessor",
-    "StateChangeProcessor",
-    "StateUpdateProcessor",
-]
+__all__ = ["RegisterProcessor", "ResponseProcessor", "StateChangeProcessor", "StateUpdateProcessor"]

--- a/src/smart_home/server/processors/__init__.py
+++ b/src/smart_home/server/processors/__init__.py
@@ -1,5 +1,11 @@
 from smart_home.server.processors.register import RegisterProcessor
 from smart_home.server.processors.response import ResponseProcessor
 from smart_home.server.processors.state_change import StateChangeProcessor
+from smart_home.server.processors.state_update import StateUpdateProcessor
 
-__all__ = ["RegisterProcessor", "ResponseProcessor", "StateChangeProcessor"]
+__all__ = [
+    "RegisterProcessor",
+    "ResponseProcessor",
+    "StateChangeProcessor",
+    "StateUpdateProcessor",
+]

--- a/src/smart_home/server/processors/state_update.py
+++ b/src/smart_home/server/processors/state_update.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from smart_home.server.events import TaskDueEvent
+from smart_home.server.state_update_sender import StateUpdateSender
+
+if TYPE_CHECKING:
+    from smart_home.server.tasks import TaskDatabase
+
+
+class StateUpdateProcessor:
+    def __init__(
+        self,
+        sender: StateUpdateSender,
+        task_database: "TaskDatabase",
+    ) -> None:
+        self._sender = sender
+        self._task_database = task_database
+
+    async def handle(self, event: TaskDueEvent) -> None:
+        task = await self._task_database.get_by_task_id(event.task_id)
+        if task is None:
+            print(f"[StateUpdateProcessor] Task {event.task_id} not found")
+            return
+
+        ok = await self._sender.send(
+            device_id=task.device_id,
+            command_type=0,
+            parameters=task.parameters,
+        )
+        if ok:
+            await self._task_database.remove_task(task.task_id)
+        else:
+            print(
+                f"[StateUpdateProcessor] Device {task.device_id} unreachable, "
+                f"task {task.task_id} stays in DB for retry"
+            )

--- a/src/smart_home/server/processors/state_update.py
+++ b/src/smart_home/server/processors/state_update.py
@@ -29,10 +29,8 @@ class StateUpdateProcessor:
             command_type=0,
             parameters=task.parameters,
         )
-        if ok:
-            await self._task_database.remove_task(task.task_id)
-        else:
+        if not ok:
             print(
                 f"[StateUpdateProcessor] Device {task.device_id} unreachable, "
-                f"task {task.task_id} stays in DB for retry"
+                f"task {task.task_id} skipped until daily reset"
             )

--- a/src/smart_home/server/server.py
+++ b/src/smart_home/server/server.py
@@ -5,20 +5,25 @@ from smart_home.common.config_loader import HOST, PORT, TICK_INTERVAL_SECONDS
 from smart_home.server.event_bus import EventBus
 from smart_home.server.scheduler import Scheduler
 from smart_home.server.tasks import TaskDatabase
+from smart_home.server.daily_task_reset import DailyTaskReset
 from smart_home.server.events import (
     DeviceRegisterEvent,
     DeviceStateChangeRespEvent,
     DeviceStateChangeEvent,
+    TaskDueEvent,
+    TickEvent,
     TimeShiftEvent,
 )
 from smart_home.server.processors import (
     RegisterProcessor,
     ResponseProcessor,
     StateChangeProcessor,
+    StateUpdateProcessor,
 )
 from smart_home.server.processors.time_shift import TimeShiftProcessor
 from smart_home.server.registry import DeviceRegistry
 from smart_home.server.state_history import DeviceStateHistory
+from smart_home.server.state_update_sender import StateUpdateSender
 from smart_home.server.tick_emitter import TickEmitter
 from smart_home.server.time_service import TimeService
 
@@ -41,11 +46,16 @@ async def start_server() -> None:
     state_change_processor = StateChangeProcessor(registry, history, time_service)
     response_processor = ResponseProcessor()
     time_shift_processor = TimeShiftProcessor(time_service)
+    state_update_sender = StateUpdateSender(registry)
+    state_update_processor = StateUpdateProcessor(state_update_sender, task_database)
+    daily_task_reset = DailyTaskReset(task_database)
 
     await bus.subscribe(DeviceRegisterEvent, register_processor.handle)
     await bus.subscribe(DeviceStateChangeEvent, state_change_processor.handle)
     await bus.subscribe(DeviceStateChangeRespEvent, response_processor.handle)
     await bus.subscribe(TimeShiftEvent, time_shift_processor.handle)
+    await bus.subscribe(TaskDueEvent, state_update_processor.handle)
+    await bus.subscribe(TickEvent, daily_task_reset.handle)
 
     tick_emitter = TickEmitter(
         bus,

--- a/src/smart_home/server/state_update_sender.py
+++ b/src/smart_home/server/state_update_sender.py
@@ -1,0 +1,35 @@
+import time
+import uuid
+
+from smart_home.proto.v1 import message_pb2
+from smart_home.server.message_handler import build_envelope, encode_wire_message
+from smart_home.server.registry import DeviceRegistry
+
+
+class StateUpdateSender:
+    def __init__(self, registry: DeviceRegistry) -> None:
+        self._registry = registry
+
+    async def send(
+        self,
+        device_id: int,
+        command_type: int,
+        parameters: dict[str, str],
+    ) -> bool:
+        writer = await self._registry.get_writer(device_id)
+        if writer is None:
+            return False
+
+        msg = message_pb2.DeviceStateUpdate()
+        msg.device_id = device_id
+        msg.command_type = command_type
+        msg.timestamp = int(time.time())
+        msg.parameters.update(parameters)
+
+        proto_bytes = build_envelope(msg)
+        request_id = str(uuid.uuid4())
+        wire_data = encode_wire_message(request_id, proto_bytes)
+
+        writer.write(wire_data)
+        await writer.drain()
+        return True

--- a/src/smart_home/server/tasks.py
+++ b/src/smart_home/server/tasks.py
@@ -91,6 +91,23 @@ class TaskDatabase:
         async with self._lock:
             return self._tasks_by_id.pop(task_id, None) is not None
 
+    async def reset_dispatched_flags(self) -> int:
+        """Mark all tasks as not dispatched. Returns the number of tasks updated."""
+        async with self._lock:
+            count = 0
+            for task_id, task in list(self._tasks_by_id.items()):
+                if not task.dispatched:
+                    continue
+                self._tasks_by_id[task_id] = ScheduledTask(
+                    task_id=task.task_id,
+                    device_id=task.device_id,
+                    parameters=dict(task.parameters),
+                    time=task.time,
+                    dispatched=False,
+                )
+                count += 1
+            return count
+
 
 def _copy_task(task: ScheduledTask) -> ScheduledTask:
     return ScheduledTask(


### PR DESCRIPTION
This adds the StateUpdateProcessor for #55 plus the daily reset piece that goes with it.

  The processor reacts to TaskDueEvent, looks the task up in TaskDatabase, and forwards it to the right device through a small StateUpdateSender helper (which builds the DeviceStateUpdate proto, wraps it in
  Envelope + wire format, and writes it via DeviceRegistry).

  The daily reset is a separate component: DailyTaskReset listens to TickEvent and, when the UTC date changes, calls a new reset_dispatched_flags method on TaskDatabase. That way tasks stay in the DB and just
  get re-armed every midnight instead of being removed after dispatch.

  Both are wired up in server.py so TaskDueEvent and TickEvent get subscribed at startup.